### PR TITLE
chore: update dependency versions in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,23 +37,23 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <version>3.3.4</version>
+            <version>3.5.7</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>3.3.4</version>
+            <version>3.5.7</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.10.1</version>
+            <version>2.13.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure-processor</artifactId>
             <optional>true</optional>
-            <version>3.3.4</version>
+            <version>3.5.7</version>
         </dependency>
         <dependency>
             <groupId>org.apache.xmlrpc</groupId>
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>3.3.4</version>
+            <version>3.5.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -73,7 +73,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.14.1</version>
                 <configuration>
                     <source>17</source>
                     <target>17</target>
@@ -82,12 +82,16 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.5.4</version>
+                <configuration>
+                    <!-- Ensure JUnit platform is used correctly -->
+                    <useModulePath>false</useModulePath>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.10</version>
+                <version>0.8.14</version>
                 <executions>
                     <execution>
                         <goals>
@@ -106,7 +110,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.10.1</version>
+                <version>3.12.0</version>
                 <configuration>
                     <outputDirectory>${project.basedir}/docs</outputDirectory> <!-- Directory di output -->
                 </configuration>
@@ -141,7 +145,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.2.7</version>
+                <version>3.2.8</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
@@ -154,7 +158,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.6.0</version>
+                <version>0.9.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
This pull request updates several dependencies and build plugins in the `pom.xml` file to more recent versions. The main focus is on keeping the project up-to-date with the latest stable releases for Spring Boot, Gson, and various Maven plugins, which should improve compatibility, security, and build reliability.

Dependency updates:

* Upgraded `spring-boot-starter`, `spring-boot-starter-web`, `spring-boot-autoconfigure-processor`, and `spring-boot-starter-test` dependencies from version `3.3.4` to `3.5.7`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L40-R56) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L66-R66)
* Upgraded `gson` dependency from `2.10.1` to `2.13.2`.

Build and test plugin updates:

* Updated `maven-compiler-plugin` from `3.13.0` to `3.14.1`, and `maven-surefire-plugin` from `2.22.2` to `3.5.4` (with added configuration for JUnit platform compatibility). [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L76-R76) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L85-R94)
* Upgraded `jacoco-maven-plugin` from `0.8.10` to `0.8.14` and `maven-javadoc-plugin` from `3.10.1` to `3.12.0`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L85-R94) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L109-R113)

Publishing and signing plugin updates:

* Updated `maven-gpg-plugin` from `3.2.7` to `3.2.8` and `central-publishing-maven-plugin` from `0.6.0` to `0.9.0`. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L144-R148) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L157-R161)